### PR TITLE
upgrade to latest alia/hayt

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  [clj-yaml                  "0.4.0"]
                  [clout                     "1.1.0"]
                  [ring/ring-codec           "1.0.0"]
-                 [cc.qbits/alia             "2.0.0-beta10"]
+                 [cc.qbits/alia             "2.0.0-rc1"]
                  [net.jpountz.lz4/lz4       "1.2.0"]
                  [org.xerial.snappy/snappy-java "1.0.5"]
                  [org.slf4j/slf4j-log4j12   "1.6.4"]

--- a/src/io/pithos/schema.clj
+++ b/src/io/pithos/schema.clj
@@ -1,8 +1,6 @@
 (ns io.pithos.schema
   "Namespace holding a single action which installs the schema"
-  (:require [qbits.hayt            :refer :all]
-            [qbits.alia            :refer [execute]]
-            [clojure.tools.logging :refer [info error]]
+  (:require [clojure.tools.logging :refer [info error]]
             [io.pithos.bucket      :as bucket]
             [io.pithos.meta        :as meta]
             [io.pithos.blob        :as blob]))

--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -5,12 +5,6 @@
             [qbits.hayt            :refer [use-keyspace create-keyspace with]]
             [clojure.tools.logging :refer [debug]]))
 
-(defmacro execute
-  "Simple macro to wrap a body in an alia session"
-  [store & body]
-  `(alia/with-session ~store
-     (do ~@body)))
-
 (defn cassandra-store
   "Connect to a cassandra cluster, and use a specific keyspace.
    When the keyspace is not found, try creating it"
@@ -18,7 +12,7 @@
     :or {hints {:replication {:class             "SimpleStrategy"
                               :replication_factor 1}}}}]
   (debug "building cassandra store for: " cluster keyspace hints)
-  (let [session (-> (alia/cluster cluster) (alia/connect))]
+  (let [session (-> (alia/cluster {:contact-points [cluster]}) (alia/connect))]
     (try (alia/execute session (use-keyspace keyspace))
          session
          (catch clojure.lang.ExceptionInfo e


### PR DESCRIPTION
- upgrade to alia 2.0-rc1
- use new Hayt where clause
- update alia/cluster options format
- pass session argument explicitly to all execute calls
- kill some unused code

This should make the transition to prepared queries painless (map keys ordering is unpredictable), and arguably more readable. 
