### PR TITLE
Properly extract uploadid from request

### DIFF
--- a/src/io/pithos/operations.clj
+++ b/src/io/pithos/operations.clj
@@ -327,10 +327,11 @@
 
 (defn abort-upload
   "Abort an ongoing upload"
-  [{:keys [bucket object uploadid] :as request} bucketstore regions]
+  [{:keys [bucket object params] :as request} bucketstore regions]
   (let [{:keys [region]}                    (bucket/by-name bucketstore bucket)
         {:keys [metastore storage-classes]} (get-region regions region)
-        blobstore                           (get storage-classes :standard)]
+        blobstore                           (get storage-classes :standard)
+        {:keys [uploadid]}                  params]
     (doseq [{:keys [inode version]}
             (meta/list-upload-parts metastore bucket object
                                     (parse-uuid uploadid))]


### PR DESCRIPTION
Fixes

```
DEBUG [2014-07-10 15:47:21,118] New I/O worker #96 - io.pithos.operations - handling operation:  :delete-object-uploadid
ERROR [2014-07-10 15:47:21,120] New I/O worker #96 - io.pithos.operations - caught exception during operation
java.lang.NullPointerException
        at java.util.UUID.fromString(UUID.java:192)
        at io.pithos.util$parse_uuid.invoke(util.clj:70)
        at io.pithos.operations$abort_upload.invoke(operations.clj:336)
```
