### PR TITLE
Do not quote ETag in put-object

### DIFF
--- a/src/io/pithos/operations.clj
+++ b/src/io/pithos/operations.clj
@@ -293,7 +293,7 @@
                         (when old-version
                           (blob/delete! blobstore inode old-version))
                         (send! (-> (response)
-                                   (header "ETag" (str "\"" checksum "\""))
+                                   (header "ETag" checksum)
                                    (request-id request))
                                (:chan request)))]
         (blob/append-stream! blobstore inode version body finalize!)))))


### PR DESCRIPTION
This looks like it was just left there by mistake. All other etags are set correctly.
Issue: #19.
