### PR TITLE
deb: depends on any Java 7 JRE

### DIFF
--- a/tasks/leiningen/fatdeb.clj
+++ b/tasks/leiningen/fatdeb.clj
@@ -60,7 +60,7 @@
               :section "base"
               :priority "optional"
               :architecture "all"
-              :depends (join ", " ["bash" "openjdk-7-jre"])
+              :depends (join ", " ["bash" "java7-runtime-headless | openjdk-7-jre-headless"])
               :maintainer (:email (:maintainer project))
               :description (:description project)})))
 


### PR DESCRIPTION
Packages providing a Java7 JRE should provide java7-runtime-headless. As
a fallback, for people without any JRE installed, we install
openjdk-7-jre-headless.
