### PR TITLE
meta: handle no delimiter case when listing objects

### DIFF
--- a/src/io/pithos/meta.clj
+++ b/src/io/pithos/meta.clj
@@ -191,9 +191,11 @@
 (defn filter-keys
   "Keep only contents in a list of objects"
   [objects prefix delimiter]
-  (if (and (seq delimiter) (seq objects))
+  (if (seq objects)
     (let [prefix    (or prefix "")
-          pat       (str "^" prefix "[^\\" delimiter "]*$")
+          no-delim  (if delimiter (str "[^\\" delimiter "]")
+                        ".")
+          pat       (str "^" prefix no-delim "*$")
           keep?     (comp (partial re-find (re-pattern pat)) :object)]
       (filter keep? objects))
     objects))

--- a/test/io/pithos/meta_test.clj
+++ b/test/io/pithos/meta_test.clj
@@ -25,7 +25,32 @@
                      #{}
                      [{:object "foo/bar.txt"}
                       {:object "foo/baz.txt"}]
-                     ""
+                     10
+                     nil
+                     false
+
+                     "simple list with prefix"
+                     [{:object "foo/bar.txt"}
+                      {:object "foo/baz.txt"}
+                      {:object "batman/foo.txt"}]
+                     "foo/"
+                     "/"
+                     #{}
+                     [{:object "foo/bar.txt"}
+                      {:object "foo/baz.txt"}]
+                     10
+                     nil
+                     false
+
+                     "with prefix but no delimiter"
+                     [{:object "foo-bar.txt"}
+                      {:object "foo-baz.txt"}
+                      {:object "batman-foo.txt"}]
+                     "foo-"
+                     nil
+                     #{}
+                     [{:object "foo-bar.txt"}
+                      {:object "foo-baz.txt"}]
                      10
                      nil
                      false


### PR DESCRIPTION
All objects were returned when the delimiter was absent. We only return
the objects with the provided prefix. A test case is added.

Another PR will follow to secure the use of regular expressions.
