### PR TITLE
http: do not use white spaces to keep the connection alive

### DIFF
--- a/src/io/pithos/operations.clj
+++ b/src/io/pithos/operations.clj
@@ -512,7 +512,7 @@
   (let [ch        (chan)
         previous  (desc/init-version od)
         push-str  (fn [type]
-                    (put! ch (case type :block "\n" :chunk " " type)))
+                    (put! ch (case type :block "" :chunk "" type)))
         etag      (promise)
         details   (meta/get-upload-details (bucket/metastore od)
                                            bucket object upload-id)


### PR DESCRIPTION
When sending either `\n` or ` ` to keep the HTTP connection alive, the
answer is also padded with those characters. An XML answer cannot start
with a whitespace. If there is an XML declaration, it must be first.

Boto is using Python XML SAX parser which doesn't like whitespaces. XML
parser in PHP doesn't like it either.

Unfortunately, with this change, Jetty doesn't send an empty chunk, it
doesn't send anything. So, this breaks the keepalived mechanism.

Also, I have absolutely no idea why we send `\n` and why we send ` ` and why this would be important.
