### PR TITLE
respond with Last-Modified header on get-object

### DIFF
--- a/src/io/pithos/operations.clj
+++ b/src/io/pithos/operations.clj
@@ -396,6 +396,7 @@
     (-> (response is)
         (content-type (desc/content-type od))
         (header "Content-Length" (- (last range) (first range)))
+        (header "Last-Modified" (iso8601->rfc822 (str (:atime od))))
         (header "ETag" (str "\"" (desc/checksum od) "\""))
         (update-in [:headers] (partial merge (:metadata od))))))
 


### PR DESCRIPTION
At least the JClouds S3 Client requires this header. I do not see why it should harm to always add it.