### PR TITLE
Use clj-time.format rfc822 formatter

### DIFF
--- a/src/io/pithos/util.clj
+++ b/src/io/pithos/util.clj
@@ -84,7 +84,7 @@
   (javax.xml.bind.DatatypeConverter/printDateTime (Calendar/getInstance @utc)))
 
 (def rfc822-format
-  (formatter "EEE, dd MMM yyyy HH:mm:ss z"))
+  (:rfc822 formatters))
 
 (defn rfc822->date
   [s]


### PR DESCRIPTION
The main difference is to use time offsets instead of the
symbolic name UTC.
According to the original RFC822 UTC would not be allowed.
According to the proposed successor RFC2822 offsets are to be
preferred to use.

RFC 822 http://www.w3.org/Protocols/rfc822/#z28
RFC 2822 http://www.rfc-editor.org/rfc/rfc2822.txt

see clj-time.format rfc822 pattern "EEE, dd MMM yyyy HH:mm:ss Z"
https://github.com/clj-time/clj-time/blob/v0.8.0/src/clj_time/format.clj#L138