### PR TITLE
Fixing up lein fatrpm, fatdeb and tar task descriptions for consistency.

### DIFF
--- a/tasks/leiningen/fatdeb.clj
+++ b/tasks/leiningen/fatdeb.clj
@@ -1,5 +1,5 @@
 (ns leiningen.fatdeb
-  "Build a .deb package from leininen, stolen from riemann"
+  "Build a .deb package from leiningen, stolen from riemann."
   (:refer-clojure :exclude [replace])
   (:require [clojure.java.shell :refer [sh]]
             [clojure.java.io    :refer [file delete-file writer copy]]

--- a/tasks/leiningen/fatrpm.clj
+++ b/tasks/leiningen/fatrpm.clj
@@ -1,5 +1,5 @@
 (ns leiningen.fatrpm
-; build a rpm, based off fatrpm in reimann
+  "Build a .rpm package from leiningen, stolen from riemann."
   (:refer-clojure :exclude [replace])
   (:use [clojure.java.shell :only [sh]]
         [clojure.java.io :only [file delete-file writer copy]]

--- a/tasks/leiningen/tar.clj
+++ b/tasks/leiningen/tar.clj
@@ -1,4 +1,5 @@
 (ns leiningen.tar
+  "Create a tarball suitable for rpm packaging, stolen from riemann."
   (:use [clojure.java.shell :only [sh with-sh-dir]]
         [clojure.java.io :only [file delete-file writer copy]]
         [clojure.string :only [join capitalize trim-newline split trim]]


### PR DESCRIPTION
Added in missing descriptions, and spelling fix.