### PR TITLE
parse more valid RFC822 dates

### DIFF
--- a/src/io/pithos/util.clj
+++ b/src/io/pithos/util.clj
@@ -5,7 +5,8 @@
            [java.lang              Math]
            [org.jboss.netty.buffer ChannelBuffers])
   (:require [clojure.string  :refer [lower-case]]
-            [clj-time.format :refer [formatters parse unparse formatter]]))
+            [clj-time.core   :as time-core]
+            [clj-time.format :refer [formatters parse unparse formatter with-zone]]))
 
 (defn md5-init
   "Yield an MD5 MessageDigest instance"
@@ -83,12 +84,74 @@
   []
   (javax.xml.bind.DatatypeConverter/printDateTime (Calendar/getInstance @utc)))
 
+
+(defn ^{:private true} formatter-with-zone
+  [s z]
+  (with-zone (formatter s) z))
+
+(def ^{:private true} rfc822-interop-format
+  "Common used date format, when rfc822 is supposed to be supported"
+  (formatter-with-zone "EEE, dd MMM yyyy HH:mm:ss 'GMT'" time-core/utc))
+
+(def ^{:private true} rfc822-obs-military-zones
+  "Map of military time zone identifiers to timezone"
+  (let [identifiers-upper "YXWVUTSRQPONZABCDEFGHIKLM"
+        identifiers-lower (.toLowerCase identifiers-upper java.util.Locale/US)
+        identifiers       (concat identifiers-upper identifiers-lower)
+        offsets           (range -12 13)
+        offset-zones      (map time-core/time-zone-for-offset offsets)]
+    (zipmap identifiers (cycle offset-zones))))
+
+(def ^{:private true} rfc822-obs-named-zones
+  "Map of RFC822 named time zone identifiers to timezone"
+  ;; this handles daylight saving times by trusting the correctness of the given string
+  ;; even if the date is given in the wrong tz (e.g. EDT in December)
+  {"UT"   time-core/utc
+   "GMT"  time-core/utc
+   "EST"  (time-core/time-zone-for-offset -5)
+   "EDT"  (time-core/time-zone-for-offset -4)
+   "CST"  (time-core/time-zone-for-offset -6)
+   "CDT"  (time-core/time-zone-for-offset -5)
+   "MST"  (time-core/time-zone-for-offset -7)
+   "MDT"  (time-core/time-zone-for-offset -6)
+   "PST"  (time-core/time-zone-for-offset -8)
+   "PDT"  (time-core/time-zone-for-offset -7)})
+
+
+(def ^{:private true} rfc822-formatters
+  "List of date formatters as specified in RFC822 (RFC2822) in order of preference"
+  (let [zone-mapping->formatter (fn [[zone offset]] (-> "EEE, dd MMM yyyy HH:mm:ss '%s'"
+                                                        (format zone)
+                                                        (formatter-with-zone offset)))]
+    (concat
+      ;; recommended date format of rfc822 successor rfc2822
+      [(formatter "EEE, dd MMM yyyy HH:mm:ss Z")]
+      [rfc822-interop-format]
+      ;; use joda time tz parsing;
+      ;; it handles summer time better if EST is given during EDT dates
+      ;; this is more lenient than RFC822 as it allows more time zone strings (e.g. UTC)
+      [(formatter "EEE, dd MMM yyyy HH:mm:ss z")]
+      (->> rfc822-obs-named-zones (map zone-mapping->formatter))
+      (->> rfc822-obs-military-zones (map zone-mapping->formatter)))))
+
+(defn ^{:private true} parse-with-formatter-safe
+  "Parses string with formatter and returns parse-error or nil"
+  ([s formatter] (parse-with-formatter-safe s formatter nil))
+  ([s formatter parse-error]
+  (try
+    (parse formatter s)
+    (catch IllegalArgumentException iae
+      parse-error))))
+
+
 (def rfc822-format
-  (formatter "EEE, dd MMM yyyy HH:mm:ss z"))
+  rfc822-interop-format)
 
 (defn rfc822->date
+  "Attempts to parse with all rfc822-formatters and returns the first non-nil result or throws an IllegalArgumentException."
   [s]
-  (parse rfc822-format s))
+  (or (some identity (map #(parse-with-formatter-safe s % nil) rfc822-formatters))
+      (throw (new IllegalArgumentException (format "Could not parse [ %s ] as RFC822 date" s)))))
 
 (defn iso8601->rfc822
   "RFC822 representation based on an iso8601 timestamp"

--- a/test/io/pithos/util_test.clj
+++ b/test/io/pithos/util_test.clj
@@ -1,7 +1,8 @@
 (ns io.pithos.util-test
   (:require [clojure.test   :refer :all]
-            [io.pithos.util :refer [inc-prefix to-bytes parse-uuid
-                                    string->pattern]]))
+            [io.pithos.util :refer [inc-prefix to-bytes parse-uuid  rfc822->date
+                                    string->pattern]]
+            [clj-time.core  :as time-core]))
 
 (deftest inc-prefix-test
   (testing "nil prefix"
@@ -58,3 +59,16 @@
   (testing "with back references"
     (is (= "\\(42\\)\\\\1\\\\k\\<here\\>"
            (string->pattern "(42)\\1\\k<here>")))))
+
+(deftest rfc822-parse-test
+  (testing "rfc822->date"
+    (is (apply = (map #(.toDateTime % time-core/utc)
+                      [(time-core/date-time 2014 10 01)
+                       (rfc822->date "Wed, 01 Oct 2014 00:00:00 GMT")
+                       (rfc822->date "Wed, 01 Oct 2014 00:00:00 UT")
+                       (rfc822->date "Wed, 01 Oct 2014 00:00:00 UTC")     ;; UTC would be invalid according to Spec
+                       (rfc822->date "Wed, 01 Oct 2014 00:00:00 +0000")
+                       (rfc822->date "Tue, 30 Sep 2014 20:00:00 EST")
+                       (rfc822->date "Wed, 01 Oct 2014 05:00:00 +0500")
+                       (rfc822->date "Tue, 30 Sep 2014 12:00:00 Y")
+                       (rfc822->date "Wed, 01 Oct 2014 12:00:00 M")])))))


### PR DESCRIPTION
This is a followup to https://github.com/exoscale/pithos/pull/55 and https://github.com/exoscale/pithos/pull/54

This pull requests adds better RFC822 parsing and uses a more common format for printing.

This should allow to pull https://github.com/exoscale/pithos/pull/54 again since the used date format is now more inline, what is commonly used when RFC822 is supported.