### PR TITLE
Putting back lein-rpm dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
   :profiles {:dev {:resource-paths ["test/data"]}}
   :plugins [[lein-sub      "0.3.0"]
             [lein-difftest "2.0.0"]
+            [lein-rpm "0.0.5"]
             [lein-ancient  "0.6.7"]]
   :sub ["pithos-quickstart"]
   :dependencies [[org.clojure/clojure           "1.7.0-beta3"]


### PR DESCRIPTION
Just adding this one back - looks like it got overwritten in an auto-merge.