### PR TITLE
cors: allow server provided default-cors rules

### DIFF
--- a/src/io/pithos/config.clj
+++ b/src/io/pithos/config.clj
@@ -132,6 +132,13 @@
         :let [reporter (merge default-reporter reporter)]]
     (get-instance reporter :reporter)))
 
+(defn parse-cors
+  [rules]
+  (let [->sym    (fn [s] (-> s name .toLowerCase keyword))
+        sanitize (fn [{:keys [methods] :as rule}]
+                   (assoc rule :methods (map ->sym methods)))]
+    (mapv sanitize rules)))
+
 (defn init
   "Parse YAML file, merge in defaults and then create instances
    where applicable"
@@ -145,6 +152,7 @@
       (-> opts
           (update-in [:service] (partial merge default-service))
           (update-in [:options] (partial merge default-options))
+          (update-in [:options :default-cors] parse-cors)
           (update-in [:keystore] (partial merge default-keystore))
           (update-in [:keystore] get-instance :keystore)
           (update-in [:bucketstore] (partial merge default-bucketstore))

--- a/src/io/pithos/operations.clj
+++ b/src/io/pithos/operations.clj
@@ -820,11 +820,15 @@
   "If an \"Origin\" header is present and we are asked to
    handle CORS rules, process them"
   [resp bucket origin system headers method]
-  (let [rules (and (or origin (= method :options))
-                   (some-> (bucket/by-name
-                            (system/bucketstore system) bucket)
-                           :cors
-                           read-string))]
+  (let [default-cors (get-in system [:options :default-cors])
+        rules        (and (or origin (= method :options))
+                          (some-> (bucket/by-name
+                                   (system/bucketstore system) bucket)
+                                  :cors
+                                  read-string
+                                  (concat default-cors)))]
+    (when rules
+      (debug "got cors rules:" (pr-str rules)))
     (if rules
       (update-in resp [:headers] merge (cors/matches? rules headers method))
       resp)))

--- a/src/io/pithos/system.clj
+++ b/src/io/pithos/system.clj
@@ -10,10 +10,14 @@
 
 (defn system-descriptor
   [config]
-  (reify SystemDescriptor
+  (reify
+    SystemDescriptor
     (regions [this] (:regions config))
     (bucketstore [this] (:bucketstore config))
     (keystore [this] (:keystore config))
     (reporters [this] (:reporters config))
     (service [this] (:service config))
-    (service-uri [this] (get-in config [:options :service-uri]))))
+    (service-uri [this] (get-in config [:options :service-uri]))
+    clojure.lang.ILookup
+    (valAt [this k] (get config k))
+    (valAt [this k default] (or (get config k) default))))


### PR DESCRIPTION
If a client interface needs automatic access to a deployed pithos installation, this will prove useful.
The configuration now accepts an addition `default-cors` option:

```yaml
options:
  default-cors:
    - origins: [ "*"]
    - methods: [ "post" ]
    - headers: [ "Content-Type" ]
    - exposed: [ ]
```