### PR TITLE
report CORS error instead of ACL error when dealing with CORS

### DIFF
--- a/src/io/pithos/cors.clj
+++ b/src/io/pithos/cors.clj
@@ -35,8 +35,8 @@
     (catch clojure.lang.ExceptionInfo e
       (throw e))
     (catch Exception e
-      (throw (ex-info "Invalid XML in ACL Body"
-                      {:type :invalid-acl-xml
+      (throw (ex-info "Invalid XML in CORS Body"
+                      {:type :invalid-cors-xml
                        :status-code 400})))))
 
 (defn xml->cors

--- a/src/io/pithos/xml.clj
+++ b/src/io/pithos/xml.clj
@@ -364,7 +364,7 @@ Will produce an XML AST equivalent to:
         [:HostId reqid]]
        :invalid-cors-xml
        [:Error
-        [:Code "MalformedCORSError"]
+        [:Code "MalformedXML"]
         [:Message (str "The XML you provided was not well-formed "
                        "or did not validate against our published schema.")]
         [:RequestId reqid]

--- a/src/io/pithos/xml.clj
+++ b/src/io/pithos/xml.clj
@@ -362,6 +362,13 @@ Will produce an XML AST equivalent to:
                        "or did not validate against our published schema.")]
         [:RequestId reqid]
         [:HostId reqid]]
+       :invalid-cors-xml
+       [:Error
+        [:Code "MalformedCORSError"]
+        [:Message (str "The XML you provided was not well-formed "
+                       "or did not validate against our published schema.")]
+        [:RequestId reqid]
+        [:HostId reqid]]
        :bucket-already-exists
        [:Error
         [:Code "BucketAlreadyExists"]


### PR DESCRIPTION
when dealing about CORS error messages report ACL errors. This aims to fix this, reporting CORS errors when dealing with CORS.