### PR TITLE
Update s3cmd example configuration to use v2 signature.

### DIFF
--- a/doc/s3cmd.cfg
+++ b/doc/s3cmd.cfg
@@ -3,6 +3,7 @@ host_base = s3.example.com
 host_bucket = %(bucket)s.s3.example.com
 access_key = AKIAIOSFODNN7EXAMPLE
 secret_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+signature_v2 = True
 # Remove those lines when not running locally:
 use_https = False
 proxy_host = localhost


### PR DESCRIPTION
2144dbefee8e822aefb4785dfb39ac60f611765e updated the documentation, but left out the sample s3cmd configuration file in `doc/`.