### PR TITLE
sig: fix signing for query string w/ empty vals

### DIFF
--- a/src/io/pithos/request.clj
+++ b/src/io/pithos/request.clj
@@ -143,7 +143,7 @@
   [suffixes]
   (fn [{:keys [uri request-method action-params target params] :as request}]
     (let [suffix  (some suffixes action-params)
-          getpair (fn [[k v]] (if v (str k "=" v) k))
+          getpair (fn [[k v]] (if (and v (seq v)) (str k "=" v) k))
           append  (some->> (filter (comp subresources key) params)
                            (map (juxt (comp subresources first) second))
                            (sort-by first)


### PR DESCRIPTION
https://docs.aws.amazon.com/general/latest/gr/signature-version-2.html
says:

   "Separate parameter names from their values with the equal sign
   character (=) (ASCII character 61), even if the value is empty."

This doesn't seem to be true for signature generation though and
existing S3 client libraries (goamz, minio-go) encounter an
authentication error when talking to Pithos, since Pithos is including
'=' for a query string '?a='.

https://github.com/aws/aws-sdk-go/blob/1a69d069352edadd48f12b0f2c5f375de4a636d7/private/signer/v2/v2.go#L133-L139
seems to confirm Pithos behavior, *but* the v2 signer in aws-sdk-go is
SimpleDB specific (see https://github.com/aws/aws-sdk-go/issues/400) and
appears to not be officially supported.

So our best guess is to follow the implementations in-use.