### PR TITLE
operations: get-object return last-modified header

### DIFF
--- a/src/io/pithos/operations.clj
+++ b/src/io/pithos/operations.clj
@@ -426,6 +426,7 @@
         (content-type (desc/content-type od))
         (header "Content-Length" (- (last range) (first range)))
         (header "ETag" (str "\"" (desc/checksum od) "\""))
+        (header "Last-Modified" (iso8601->rfc822 (str (:atime od))))
         (update-in [:headers] (partial merge (:metadata od))))))
 
 (defn put-object


### PR DESCRIPTION
Last-Modified header is only returned on HEAD object.

I haven't tested this.