### PR TITLE
operations: stricter rules for bucket naming.

### DIFF
--- a/test/io/pithos/operations_test.clj
+++ b/test/io/pithos/operations_test.clj
@@ -210,6 +210,16 @@
                            :body (java.io.ByteArrayInputStream. (.getBytes "foobar"))})]
         (is (= (:status resp) 404))))
 
+    (testing "invalid bucket names"
+      (doseq [bname ["foo bar" "foo@bar" "foo\nbar" "foo%bar" ""
+                     "thisbucketnameiswaytoolongbecauseitismorethan63characterslongwhichistoolong"]]
+        (let [resp (handler {:request-method :put
+                             :headers {"host" (format "%s.blob.example.com" bname)
+                                       "date" (date!)}
+                             :sign-uri (format "/%s/" bname)
+                             :uri "/"})]
+          (= (:status resp) 400))))
+
     (testing "put bucket"
       (handler {:request-method :put
                 :headers {"host" "batman.blob.example.com"


### PR DESCRIPTION
This restricts what a bucket name be composed of to the
following heuristic:

- A string of 3 to 63 characters.
- Alphanumeric characters.
- Dots, hyphens and underscores allowed.