### PR TITLE
store: per request consistency options

### DIFF
--- a/src/io/pithos/meta.clj
+++ b/src/io/pithos/meta.clj
@@ -2,7 +2,7 @@
   "The metastore is region-local and stores details of bucket content
    (bucket contents are region-local as well)."
   (:refer-clojure :exclude [update])
-  (:require [qbits.alia      :refer [execute]]
+  (:require [qbits.alia      :as a]
             [qbits.hayt      :refer [select where set-columns columns
                                      delete update limit map-type
                                      create-table column-definitions
@@ -238,20 +238,25 @@
 
 (defn cassandra-meta-store
   "Given a cluster configuration, reify an instance of Metastore"
-  [config]
-  (let [session (store/cassandra-store config)]
+  [{:keys [read-consistency write-consistency] :as config}]
+  (let [copts   (dissoc config :read-consistency :write-consistency)
+        session (store/cassandra-store copts)
+        rdcty   (or (some-> read-consistency keyword) :quorum)
+        wrcty   (or (some-> write-consistency keyword) :quorum)
+        read!   (fn [query] (a/execute session query {:consistency rdcty}))
+        write!  (fn [query] (a/execute session query {:consistency wrcty}))]
     (reify
       store/Convergeable
       (converge! [this]
-        (execute session object-table)
-        (execute session upload-table)
-        (execute session object_uploads-table)
-        (execute session object_inode-index)
-        (execute session upload_bucket-index))
+        (write! object-table)
+        (write! upload-table)
+        (write! object_uploads-table)
+        (write! object_inode-index)
+        (write! upload_bucket-index))
       store/Crudable
       (fetch [this bucket object fail?]
         (or
-         (first (execute session (get-object-q bucket object)))
+         (first (read! (get-object-q bucket object)))
          (when fail?
            (throw (ex-info "no such key" {:type :no-such-key
                                           :status-code 404
@@ -259,29 +264,29 @@
       (fetch [this bucket object]
         (store/fetch this bucket object true))
       (update! [this bucket object columns]
-        (execute session (update-object-q bucket object columns)))
+        (write! (update-object-q bucket object columns)))
       (delete! [this bucket object]
-        (execute session (delete-object-q bucket object)))
+        (write! (delete-object-q bucket object)))
       Metastore
       (prefixes [this bucket params]
         (get-prefixes
          (fn [prefix marker limit]
            (when (and (number? limit) (pos? limit))
-             (execute session (fetch-object-q bucket prefix marker limit))))
+             (read! (fetch-object-q bucket prefix marker limit))))
          params))
       (initiate-upload! [this bucket object upload metadata]
-        (execute session (initiate-upload-q bucket object upload metadata)))
+        (write! (initiate-upload-q bucket object upload metadata)))
       (abort-multipart-upload! [this bucket object upload]
-        (execute session (abort-multipart-upload-q bucket object upload))
-        (execute session (delete-upload-parts-q bucket object upload)))
+        (write! (abort-multipart-upload-q bucket object upload))
+        (write! (delete-upload-parts-q bucket object upload)))
       (update-part! [this bucket object upload partno columns]
-        (execute session (update-part-q bucket object upload partno columns)))
+        (write! (update-part-q bucket object upload partno columns)))
       (get-upload-details [this bucket object upload]
         (first
-         (execute session (get-upload-details-q bucket object upload))))
+         (read! (get-upload-details-q bucket object upload))))
       (list-uploads [this bucket]
-        (execute session (list-uploads-q bucket)))
+        (read! (list-uploads-q bucket)))
       (list-object-uploads [this bucket object]
-        (execute session (list-object-uploads-q bucket object)))
+        (read! (list-object-uploads-q bucket object)))
       (list-upload-parts [this bucket object upload]
-        (execute session (list-upload-parts-q bucket object upload))))))
+        (read! (list-upload-parts-q bucket object upload))))))

--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -23,8 +23,7 @@
                     {:replication {:class             "SimpleStrategy"
                                    :replication_factor (or repfactor 1)}})
         cluster (if (sequential? cluster) cluster [cluster])
-        session (-> {:contact-points cluster
-                     :query-options {:consistency :quorum}}
+        session (-> {:contact-points cluster}
                     (cond-> (and username password)
                       (assoc :credentials {:username username
                                            :password password}))


### PR DESCRIPTION
Instead of hardcoding the consistency level for pithos queries,
leave it to installations to specify it.

We let each store create functions to execute at write or read
consistency level. The default is quorum for all queries.