### PR TITLE
operations: add content-range header in response

### DIFF
--- a/src/io/pithos/operations.clj
+++ b/src/io/pithos/operations.clj
@@ -459,7 +459,13 @@
         (catch Exception e
           (error e "could not completely write out: "))))
     (-> (response is)
-        (status (if has-range? 206 200))
+        (status 200)
+        (cond-> has-range? (status 206)
+                has-range? (header "Content-Range"
+                                   (format "bytes=%s-%s/%s"
+                                           (first range)
+                                           (last range)
+                                           (desc/size od))))
         (content-type (desc/content-type od))
         (header "Content-Length" (- (last range) (first range)))
         (header "ETag" (str "\"" (desc/checksum od) "\""))


### PR DESCRIPTION
Without this, 206 ressponses emitted by pithos are not RFC7233 compliant.