### PR TITLE
Treat empty delimiters as nils

### DIFF
--- a/src/io/pithos/meta.clj
+++ b/src/io/pithos/meta.clj
@@ -213,13 +213,19 @@
                           :object)]
        (remove nil? (map ->prefix objects))))))
 
+(defn normalize-params
+  [{:keys [delimiter] :as params}]
+  (if (seq delimiter)
+    params
+    (dissoc params :delimiter)))
+
 (defn get-prefixes
   "Paging logic for keys"
   [fetcher {:keys [prefix delimiter max-keys marker]}]
   (loop [objects    (fetcher prefix (or marker prefix) max-keys)
          prefixes   #{}
          keys       []]
-    (let [prefixes (if (seq delimiter)
+    (let [prefixes (if delimiter
                      (union prefixes (filter-prefixes objects prefix delimiter))
                      #{})
           new-keys  (remove prefixes (filter-keys objects prefix delimiter))
@@ -268,7 +274,7 @@
          (fn [prefix marker limit]
            (when (and (number? limit) (pos? limit))
              (execute session (fetch-object-q bucket prefix marker limit))))
-         params))
+         (normalize-params params)))
       (initiate-upload! [this bucket object upload metadata]
         (execute session (initiate-upload-q bucket object upload metadata)))
       (abort-multipart-upload! [this bucket object upload]


### PR DESCRIPTION
When we have no value for the delimiter query arg, treat it as nil. This will fix #80 