### PR TITLE
blob: fetch chunks in slices to relieve memory pressure.

### DIFF
--- a/src/io/pithos/blob.clj
+++ b/src/io/pithos/blob.clj
@@ -150,6 +150,7 @@
                          [= :block block]])))
 
 (defn next-offset
+  "Given a range of chunks, fetch the next probable offset"
   [slice]
   (let [{:keys [offset chunksize]} (last slice)]
     (when (and offset chunksize)

--- a/src/io/pithos/blob.clj
+++ b/src/io/pithos/blob.clj
@@ -47,11 +47,6 @@
 ;; All storage protocols expose functions to produce side-effects
 ;; and a `converge!` function whose role is to apply the schema
 
-(def absolute-chunk-limit
-  "max block per chunk can be exceeded when small chunks are uploaded.
-  set a large limit of chunks to retrieve from a block."
-  524288)
-
 (def slice-width
   "Provide a sensible default for fetching chunk slices."
   1024)


### PR DESCRIPTION
This is a follow-up to https://github.com/exoscale/pithos/commit/548795e2bb1217efb8edeb2dc9588041da820872.
Instead of second-guessing what a sensible maximum would be for
chunks sizes, do a lazy fetch. Lazyness is alright here since
we always consume the resulting seq with doseq or last.