### PR TITLE
operations: encode source when copying object

### DIFF
--- a/src/io/pithos/operations.clj
+++ b/src/io/pithos/operations.clj
@@ -91,20 +91,22 @@
                                                    (str "/" source))
                                                  #"/"
                                                  3)]
-        (if (seq prefix)
-          (throw (ex-info "invalid" {:type :invalid-request :status-code 400}))
-          (when (perms/authorize {:bucket s-bucket
-                                  :object s-object
-                                  :authorization authorization}
-                                 [[:bucket :READ]]
-                                 system)
-            (let [src (desc/object-descriptor system s-bucket s-object)]
-              (when-not (desc/init-version src)
-                (throw (ex-info "no such key" {:type :no-such-key
-                                               :key  s-object})))
-              [src (if update-metadata?
-                     (get-metadata headers)
-                     (:metadata src))])))
+        (let [s-bucket (util/uri-decode s-bucket)
+              s-object (util/uri-decode s-object)]
+          (if (seq prefix)
+            (throw (ex-info "invalid" {:type :invalid-request :status-code 400}))
+            (when (perms/authorize {:bucket s-bucket
+                                    :object s-object
+                                    :authorization authorization}
+                                   [[:bucket :READ]]
+                                   system)
+              (let [src (desc/object-descriptor system s-bucket s-object)]
+                (when-not (desc/init-version src)
+                  (throw (ex-info "no such key" {:type :no-such-key
+                                                 :key  s-object})))
+                [src (if update-metadata?
+                       (get-metadata headers)
+                       (:metadata src))]))))
         (throw (ex-info "invalid" {:type :invalid-request :status-code 400})))
       [nil (get-metadata headers)])))
 

--- a/src/io/pithos/request.clj
+++ b/src/io/pithos/request.clj
@@ -6,7 +6,7 @@
             [clojure.pprint                   :refer [pprint]]
             [io.pithos.sig                    :refer [validate check-sig anonymous]]
             [io.pithos.system                 :refer [service-uri keystore]]
-            [io.pithos.util                   :refer [string->pattern]]
+            [io.pithos.util                   :refer [string->pattern uri-decode]]
             [clout.core                       :as c]
             [ring.middleware.multipart-params :as mp]
             [ring.util.request                :as req]
@@ -97,11 +97,6 @@
    :versioning "versioning"
    :versions "versions"
    :website "website"})
-
-(defn uri-decode
-  [s]
-  (when s
-    (java.net.URLDecoder/decode s "UTF-8")))
 
 (defn action-routes
   "Really simple router, extracts target (service, bucket or object)"

--- a/src/io/pithos/util.clj
+++ b/src/io/pithos/util.clj
@@ -8,6 +8,11 @@
             [clj-time.core   :refer [now]]
             [clj-time.format :refer [formatters parse unparse formatter]]))
 
+(defn uri-decode
+  [s]
+  (when s
+    (java.net.URLDecoder/decode s "UTF-8")))
+
 (defn md5-init
   "Yield an MD5 MessageDigest instance"
   []


### PR DESCRIPTION
When copying from an existing key, ensure that we correctly decode the source bucket and key.