### PR TITLE
Use exit code 1 if install schema fails, or 0 otherwise

### DIFF
--- a/src/io/pithos/schema.clj
+++ b/src/io/pithos/schema.clj
@@ -20,11 +20,10 @@
          (doseq [[storage-class blobstore] storage-classes]
            (info "converging blobstore for region and storage-class "
                  region storage-class)
-           (store/converge! blobstore)))
-
+           (store/converge! blobstore))
+         (when exit? (System/exit 0)))
        (catch Exception e
-         (error e "cannot create schema"))
-       (finally
-         (when exit? (System/exit 0)))))
+          (error e "cannot create schema")
+          (when exit? (System/exit 1)))))
   ([system]
      (converge-schema system true)))


### PR DESCRIPTION
After running into the inconvenience of detecting a failed 'install-schema' action due to 'successful' exit codes, I attempted to make  the exit codes more accurate.

I will admit that I am a clojure novice, so apologies if this is non-idiomatic.