### PR TITLE
Fix #121 -- give uploader FULL_CONTROL permissions

### DIFF
--- a/src/io/pithos/operations.clj
+++ b/src/io/pithos/operations.clj
@@ -492,7 +492,7 @@
   (let [dst         od
         previous    (desc/init-version dst)
         ctype       (get (:headers request) "content-type")
-        target-acl  (perms/header-acl (-> request :bd :tenant)
+        target-acl  (perms/header-acl (-> request :od :tenant)
                                       (:tenant authorization)
                                       (:headers request))
         [src meta]  (get-source request system)]

--- a/src/io/pithos/perms.clj
+++ b/src/io/pithos/perms.clj
@@ -108,8 +108,10 @@
 
 (defn header-acl
   [owner tenant headers]
-  (let [init          {:FULL_CONTROL [{:ID owner
-                                       :DisplayName owner}]}
+  (let [init          (if (= owner tenant)
+                        {:FULL_CONTROL [{:ID owner :DisplayName owner}]}
+                        {:FULL_CONTROL [{:ID owner :DisplayName owner}
+                                        {:ID tenant :DisplayName tenant}]})
         canned-acl    (get headers "x-amz-acl")
         acl-read      (some-> (get headers "x-amz-grant-read")
                               (split #","))


### PR DESCRIPTION
When bucket owner != tenant, give them both FULL_CONTROL permissions instead
of only the bucket owner. Additionally request only has `:od` in
`put-object`. This avoids getting 'nil' grantees in ACLs.