### PR TITLE
meta: include object itself in prefix search. fixes #117

### DIFF
--- a/test/io/pithos/meta_test.clj
+++ b/test/io/pithos/meta_test.clj
@@ -18,6 +18,17 @@
                      nil
                      false
 
+                     "object shows up"
+                     [{:object "foo.txt"}]
+                     "foo.txt"
+                     "/"
+                     #{}
+                     [{:object "foo.txt"}]
+                     10
+                     nil
+                     false
+
+
                      "no delimiter"
                      [{:object "foo/bar.txt"}
                       {:object "foo/baz.txt"}]
@@ -71,7 +82,7 @@
   "Provide a simulation of cassandra's wide row storage for testing
    Alternate store implementations will need to provide the same properties"
   [input]
-  (fn [prefix marker limit]
+  (fn [prefix marker limit init?]
     (let [>pred   #(or (= (:object %) (or marker prefix))
                        (not (.startsWith (or (:object %) "")
                                          (or marker prefix ""))))

--- a/test/io/pithos/operations_test.clj
+++ b/test/io/pithos/operations_test.clj
@@ -91,7 +91,7 @@
     meta/Metastore
     (prefixes [this bucket params]
       (meta/get-prefixes
-       (fn [prefix marker limit]
+       (fn [prefix marker limit init?]
          (let [>pred   #(or (= (:object %) (or marker prefix))
                             (not (.startsWith (or (:object %) "")
                                               (or marker prefix ""))))


### PR DESCRIPTION
In object lists, when the given prefix is itself a key, it
is excluded from search results. This introduces a behavioral change
from AWS S3's approach and breaks s3cmd for cases such as:

```
   s3cmd ls s3://bucket/object.txt
```
Provided here is a slight modification to the fetcher callback
signature, accounting for an `init?` argument where queries
may include the prefix itself in searches.