### PR TITLE
operations: add get-bucket-requestpayment handler

### DIFF
--- a/src/io/pithos/operations.clj
+++ b/src/io/pithos/operations.clj
@@ -390,6 +390,10 @@
   (-> (xml/bucket-lifecycle)
       (xml-response)))
 
+(defn get-bucket-requestpayment
+  [request system]
+  (xml-response (xml/bucket-requestpayment)))
+
 (defn put-bucket-versioning
   "No versioning support for now even though versions are stored"
   [{:keys [bucket] :as request} system]
@@ -823,6 +827,9 @@
    :get-bucket-uploads      {:handler get-bucket-uploads
                              :perms   [[:bucket :READ]]
                              :target  :bucket}
+   :get-bucket-requestpayment {:handler get-bucket-requestpayment
+                               :perms [[:bucket :READ]]
+                               :target :bucket}
    :options-object          {:handler options-object
                              :target  :bucket
                              :cors?   true

--- a/src/io/pithos/xml.clj
+++ b/src/io/pithos/xml.clj
@@ -267,6 +267,12 @@ Will produce an XML AST equivalent to:
      (for [object objects]
        [:Deleted [:Key (str object)]])]))
 
+(defn bucket-requestpayment
+  []
+  (seq->xmlstr
+   [:RequestPaymentConfiguration xml-ns
+    [:Payer "BucketOwner"]]))
+
 (defn get-bucket-versioning
   "Template for the get bucket versioning response"
   [versioned?]


### PR DESCRIPTION
Since pithos does not support request payment options, this is
a noop for now and fixes visual inconveniences.