### PR TITLE
sig: consider authenticated users members of anonymous users as well

### DIFF
--- a/src/io/pithos/sig.clj
+++ b/src/io/pithos/sig.clj
@@ -115,5 +115,6 @@
                              :status-code 403
                              :request request
                              :expires (date->rfc822 expires)})))))
-      (update-in authorization [:memberof] concat ["authenticated-users"]))
+      (update-in authorization [:memberof] concat ["authenticated-users"
+                                                   "anonymous"]))
     anonymous))


### PR DESCRIPTION
This allows authenticated users to access objects with public-read-like permissions.