### PR TITLE
desc: warn on attempts to write incomplete metadata

### DIFF
--- a/src/io/pithos/desc.clj
+++ b/src/io/pithos/desc.clj
@@ -112,6 +112,15 @@
                                :atime ts})
                        (merge @cols)
                        (dissoc :bucket :object))]
+          (when-not (and (:inode meta)
+                         (:version meta)
+                         (:size meta)
+                         (:checksum meta))
+            (error "trying to write incomplete metadata"
+                   (pr-str meta))
+            (throw (ex-info "bad metadata" {:type :incomplete-metadata
+                                            :status-code 500
+                                            :meta (pr-str meta)})))
           (store/update! metastore bucket object meta)
           (swap! cols assoc :atime ts)))
       clojure.lang.ILookup

--- a/src/io/pithos/xml.clj
+++ b/src/io/pithos/xml.clj
@@ -424,6 +424,10 @@ Will produce an XML AST equivalent to:
         [:Code "NoSuchLifecycleConfiguration"]
         [:Message "The lifecycle configuration does not exist"]
         [:BucketName (:bucket payload)]]
+       :incomplete-metadata
+       [:Error
+        [:Code "IncompleteMetadata"]
+        [:Message (str "Incomplete metadata: " (:meta payload))]]
        :no-such-tag-set
        [:Error
         [:Code "NoSuchTagSet"]


### PR DESCRIPTION
Real-world usage reports show that some conditions may lead to partial metadata being written on objects.
This captures the condition, fails requests and provides context to better get at the root-cause of such issues.