### PR TITLE
allow threading of cassandra cluster options through alia

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [ring/ring-core                "1.3.2"
                   :exclusions [org.clojure/tools.reader]]
                  [ring/ring-codec               "1.0.0"]
-                 [cc.qbits/alia                 "3.1.10"]
+                 [cc.qbits/alia                 "3.3.0"]
                  [cc.qbits/hayt                 "3.0.1"]
                  [cc.qbits/jet                  "0.7.9"
                   :exclusions [org.clojure/tools.reader]]

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  [spootnik/uncaught             "0.5.3"]
                  [clj-yaml                      "0.4.0"]
                  [clout                         "2.1.2"]
-                 [cheshire                      "5.5.0"]
+                 [cheshire                      "5.6.3"]
                  [clj-time                      "0.9.0"]
                  [ring/ring-core                "1.3.2"
                   :exclusions [org.clojure/tools.reader]]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :main io.pithos
   :jvm-opts ["-Xmx2g"]
   :profiles {:dev {:resource-paths ["test/data"]}}
-  :dependencies [[org.clojure/clojure           "1.8.0"]
+  :dependencies [[org.clojure/clojure           "1.9.0-alpha14"]
                  [org.clojure/data.codec        "0.1.0"]
                  [org.clojure/data.xml          "0.0.8"]
                  [org.clojure/data.zip          "0.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [ring/ring-core                "1.3.2"
                   :exclusions [org.clojure/tools.reader]]
                  [ring/ring-codec               "1.0.0"]
-                 [cc.qbits/alia                 "3.3.0"]
+                 [cc.qbits/alia-all             "3.3.0"]
                  [cc.qbits/hayt                 "3.0.1"]
                  [cc.qbits/jet                  "0.7.9"
                   :exclusions [org.clojure/tools.reader]]

--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -17,13 +17,14 @@
 (defn cassandra-store
   "Connect to a cassandra cluster, and use a specific keyspace.
    When the keyspace is not found, try creating it"
-  [{:keys [cluster keyspace hints repfactor username password]}]
+  [{:keys [cluster keyspace hints repfactor username password] :as opts}]
   (debug "building cassandra store for: " cluster keyspace hints)
   (let [hints   (or hints
                     {:replication {:class             "SimpleStrategy"
                                    :replication_factor (or repfactor 1)}})
+        copts   (dissoc opts :cluster :keyspace :hints :repfactor :username :password)
         cluster (if (sequential? cluster) cluster [cluster])
-        session (-> {:contact-points cluster}
+        session (-> (assoc copts :contact-points cluster)
                     (cond-> (and username password)
                       (assoc :credentials {:user username
                                            :password password}))

--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -17,16 +17,15 @@
 (defn cassandra-store
   "Connect to a cassandra cluster, and use a specific keyspace.
    When the keyspace is not found, try creating it"
-  [{:keys [cluster keyspace hints repfactor username password] :as opts}]
+  [{:keys [cassandra-options cluster keyspace hints repfactor username password]}]
   (debug "building cassandra store for: " cluster keyspace hints)
   (let [hints   (or hints
-                    {:replication {:class             "SimpleStrategy"
+                    {:replication {:class              "SimpleStrategy"
                                    :replication_factor (or repfactor 1)}})
-        copts   (dissoc opts :cluster :keyspace :hints :repfactor :username :password :use :default-region)
         cluster (if (sequential? cluster) cluster [cluster])
-        session (-> (assoc copts :contact-points cluster)
+        session (-> (assoc cassandra-options :contact-points cluster)
                     (cond-> (and username password)
-                      (assoc :credentials {:user username
+                      (assoc :credentials {:user     username
                                            :password password}))
                     (alia/cluster)
                     (alia/connect))]

--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -22,7 +22,7 @@
   (let [hints   (or hints
                     {:replication {:class             "SimpleStrategy"
                                    :replication_factor (or repfactor 1)}})
-        copts   (dissoc opts :cluster :keyspace :hints :repfactor :username :password)
+        copts   (dissoc opts :cluster :keyspace :hints :repfactor :username :password :use)
         cluster (if (sequential? cluster) cluster [cluster])
         session (-> (assoc copts :contact-points cluster)
                     (cond-> (and username password)

--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -22,7 +22,7 @@
   (let [hints   (or hints
                     {:replication {:class             "SimpleStrategy"
                                    :replication_factor (or repfactor 1)}})
-        copts   (dissoc opts :cluster :keyspace :hints :repfactor :username :password :use)
+        copts   (dissoc opts :cluster :keyspace :hints :repfactor :username :password :use :default-region)
         cluster (if (sequential? cluster) cluster [cluster])
         session (-> (assoc copts :contact-points cluster)
                     (cond-> (and username password)


### PR DESCRIPTION
Options specified in https://mpenet.github.io/alia/qbits.alia.html#var-cluster will now be directly threaded to the client library.