### PR TITLE
WIP: Signature 4 support

### DIFF
--- a/doc/pithos.yaml
+++ b/doc/pithos.yaml
@@ -15,6 +15,12 @@ keystore:
       master: true
       tenant: test@example.com
       secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+    AKIDEXAMPLE:
+      master: true
+      tenant: test@example.com
+      secret: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY'
+
+
 bucketstore:
   default-region: myregion
   cluster: "localhost"

--- a/src/io/pithos/request.clj
+++ b/src/io/pithos/request.clj
@@ -1,7 +1,7 @@
 (ns io.pithos.request
   "This namespace provides all necessary wrapper functions to validate and
    augment the incoming request map."
-  (:require [clojure.string                   :refer [lower-case join]]
+  (:require [clojure.string                   :refer [lower-case join starts-with?]]
             [clojure.tools.logging            :refer [debug info warn error]]
             [clojure.pprint                   :refer [pprint]]
             [clojure.java.io                  :as io]
@@ -237,7 +237,7 @@
                                                 .getBytes
                                                 base64/decode))
                                    true)))
-    (contains? (get req :headers) "authorization")
+    (and (contains? (get req :headers) "authorization") (starts-with? (get (get req :headers) "authorization") "AWS4-"))
     (assoc req :authorization (validate4 (keystore system) req))
     :else
     (let [auth   (validate (keystore system) req)

--- a/src/io/pithos/sig4.clj
+++ b/src/io/pithos/sig4.clj
@@ -203,14 +203,18 @@
   (let [
     authorization (parse-authorization request)
     secret-key (get (get keystore (get authorization :access-key)) :secret)
-    is-valid-signature (is-signed-by? request authorization secret-key)]
+    is-valid-signature (is-signed-by? request authorization secret-key)
+    auth (get keystore (get authorization :access-key))
+    retval (cond
+      is-valid-signature
+      (update-in auth [:memberof] concat ["authenticated-users" "anonymous"])
+      :else
+      {:tenant :anonymous :memberof ["anonymous"]}
+      )]
     (debug "request" request)
     (debug "authorization" (get keystore (get authorization :access-key)))
     (debug "secret" secret-key)
     (debug "is-valid-sig" is-valid-signature)
-    (cond
-      is-valid-signature
-      {:tenant (get authorization :tenant) :memberof ["authenticated-users", "anonymous"]}
-      :else
-      {:tenant :anonymous :memberof ["anonymous"]}
-      )))
+    (debug "retval" retval)
+    retval
+    ))

--- a/src/io/pithos/sig4.clj
+++ b/src/io/pithos/sig4.clj
@@ -129,7 +129,11 @@
   ;;    (sha256)
   ;;    (hex)
   ;;))
-  (hex (sha256 (get request :contents))))
+  (cond
+    (= (get (get request :headers) "x-amz-content-sha256") "UNSIGNED-PAYLOAD")
+    "UNSIGNED-PAYLOAD"
+    :else
+    (hex (sha256 (get request :contents)))))
 
 (defn canonical-request [request include-headers]
   (str/join "\n" [

--- a/src/io/pithos/sig4.clj
+++ b/src/io/pithos/sig4.clj
@@ -1,0 +1,165 @@
+(ns io.pithos.sig4
+  (:require [clojure.string :as str]
+            [clojure.tools.logging     :refer [info debug]]
+            [clj-time.core :as time]
+            [clj-time.format :as format])
+  (:import  [org.apache.http.entity StringEntity]
+            [javax.crypto Mac]
+            [javax.crypto.spec SecretKeySpec]
+            [java.security MessageDigest]))
+
+(defn parse-authorization [request]
+  """
+  Parse an AWS SIG4 authorization header.. e.g.
+
+  AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20170805/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=fadf01d63c3c6e4c8238625fc971eddf7a1b2d0470750a21ae8f33c03b4bbdb7
+
+  TYPE<SPACE>KEY=VALUE/VALUE/VALUE,KEY=VALUE;VALUE;VALUE,KEY=VALUE
+  """
+  (let [
+    authorization-header (get (get request :headers) "authorization")
+    authorization (zipmap [:access-key :date :region :service :signed-headers :signature]
+      (rest (re-find #"AWS4-HMAC-SHA256 Credential=(\w+)\/(\d{8})\/([\w\d-]+)\/([\w\d]+)\/aws4_request,[ ]*SignedHeaders=([\w-;]+),[ ]*Signature=(\w+)" authorization-header))
+    )]
+    (assoc authorization :signed-headers (str/split (get authorization :signed-headers) #";"))
+  ))
+
+(defn sha256 [input]
+  (let [hash (MessageDigest/getInstance "SHA-256")]
+    (. hash digest input)))
+
+(defn secretKeyInst [key mac]
+    (SecretKeySpec. key (.getAlgorithm mac)))
+
+(defn hmac-sha256 [key string]
+  "Returns the signature of a string with a given key, using a SHA-256 HMAC."
+  (let [mac (Mac/getInstance "HMACSHA256")
+        secretKey (secretKeyInst key mac)]
+    (-> (doto mac
+          (.init secretKey)
+          (.update (.getBytes string)))
+        .doFinal)))
+
+(defn hex [input]
+  """ Format bytes as a hex string """
+  (apply str (map #(format "%02x" %) input)))
+
+(defn bytes [input]
+  """ Format a string as bytes """
+  (. input getBytes))
+
+(defn request-time [request]
+  """ Parse the date or x-amzdate headers and return a time object """
+  (let [headers (get request :headers)]
+    (cond
+      (contains? headers "x-amz-date")
+      (format/parse (format/formatters :basic-date-time-no-ms) (get headers "x-amz-date"))
+      (contains? headers "date")
+      (format/parse (format/formatters :basic-date-time-no-ms) (get headers "date"))
+      )))
+
+(defn signing-key [secret-key request-time authorization]
+  """ Generate a signing key for a v4 signature """
+  (debug secret-key)
+  (-> (str "AWS4" secret-key)
+      (bytes)
+      (hmac-sha256 (format/unparse (format/formatters :basic-date) request-time))
+      (hmac-sha256 (get authorization :region))
+      (hmac-sha256 (get authorization :service))
+      (hmac-sha256 "aws4_request")
+  ))
+
+(defn canonical-verb [request]
+  ( -> (get request :request-method) name str/upper-case))
+
+(defn canonical-uri [request]
+  (get request :orig-uri))
+
+(defn canonical-query-string [request]
+  (str/join "&"
+    (->> (get request :params)
+         (map (juxt (comp name key) (comp str/trim (fn [input] (if (nil? input) "" input)) val)))
+         (sort-by first)
+         (map (partial str/join "="))
+    )))
+
+(defn canonical-headers [request, include-headers]
+    (str/join "\n"
+            (concat (->> (select-keys (get request :headers) include-headers)
+                         (map (juxt (comp name key) (comp str/trim val)))
+                         (sort-by first)
+                         (map (partial str/join ":")))
+                    )))
+
+(defn signed-headers [include-headers]
+  (str/join ";" (sort-by first include-headers)))
+
+(defn hash-payload [request]
+  """ Hash the entire body. FIXME: This has a side effect, body can only be read once. """
+  (-> (get request :body)
+      (slurp)
+      (bytes)
+      (sha256)
+      (hex)
+  ))
+
+(defn canonical-request [request include-headers]
+  (str/join "\n" [
+    (canonical-verb request)
+    (canonical-uri request)
+    (canonical-query-string request)
+    (canonical-headers request include-headers)
+    (str "\n" (signed-headers include-headers))
+    (hash-payload request)
+  ]))
+
+(defn string-to-sign [request request-time authorization]
+  """ Format a request into a canonicalized representation for signing """
+  (debug "canonical-request", (canonical-request request (get authorization :signed-headers)))
+  (str/join "\n" [
+    "AWS4-HMAC-SHA256"
+    (format/unparse (format/formatters :basic-date-time-no-ms) request-time)
+    (str/join "/" [
+      (format/unparse (format/formatters :basic-date) request-time)
+      (get authorization :region)
+      (get authorization :service)
+      "aws4_request"
+    ])
+    (hex (sha256 (bytes (canonical-request request (get authorization :signed-headers)))))
+  ]))
+
+(defn signature [signing-key, string-to-sign]
+  """ Sign a canonicalized representation of the request with a signing key """
+  (hex (hmac-sha256 signing-key string-to-sign)))
+
+(defn is-signed-by? [request authorization secret-key]
+  (let[
+    request-time (request-time request)
+    signing-key (signing-key secret-key request-time authorization)
+    string-to-sign (string-to-sign request request-time authorization)
+    signature (signature signing-key, string-to-sign)
+    ]
+    (debug request-time)
+    (debug (hex signing-key))
+    (debug string-to-sign)
+    (debug signature (get authorization :signature) (= signature (get authorization :signature)))
+    (= signature (get authorization :signature))
+  )
+)
+
+(defn validate4
+  [keystore request]
+  (let [
+    authorization (parse-authorization request)
+    secret-key (get (get keystore (get authorization :access-key)) :secret)
+    is-valid-signature (is-signed-by? request authorization secret-key)]
+    (debug "request" request)
+    (debug "authorization" (get keystore (get authorization :access-key)))
+    (debug "secret" secret-key)
+    (debug "is-valid-sig" is-valid-signature)
+    (cond
+      is-valid-signature
+      {:tenant (get authorization :tenant) :memberof ["authenticated-users", "anonymous"]}
+      :else
+      {:tenant :anonymous :memberof ["anonymous"]}
+      )))

--- a/src/io/pithos/sig4.clj
+++ b/src/io/pithos/sig4.clj
@@ -83,7 +83,7 @@
 (defn uri-escape [unencoded]
   (str/replace
     unencoded
-    #"[^A-Za-z0-9_~.-/]+"
+    #"[^A-Za-z0-9_~.\-/]+"
     #(double-escape (percent-encode %))))
 
 (defn query-escape [unencoded]

--- a/src/io/pithos/sig4.clj
+++ b/src/io/pithos/sig4.clj
@@ -115,12 +115,13 @@
 
 (defn hash-payload [request]
   """ Hash the entire body. FIXME: This has a side effect, body can only be read once. """
-  (-> (get request :body)
-      (slurp)
-      (bytes)
-      (sha256)
-      (hex)
-  ))
+  ;;(-> (get request :body)
+  ;;    (slurp)
+  ;;    (bytes)
+  ;;    (sha256)
+  ;;    (hex)
+  ;;))
+  (hex (sha256 (get request :contents))))
 
 (defn canonical-request [request include-headers]
   (str/join "\n" [
@@ -128,13 +129,13 @@
     (canonical-uri request)
     (canonical-query-string request)
     (canonical-headers request include-headers)
-    (str "\n" (signed-headers include-headers))
+    ""
+    (signed-headers include-headers)
     (hash-payload request)
   ]))
 
 (defn string-to-sign [request request-time authorization]
   """ Format a request into a canonicalized representation for signing """
-  (debug "canonical-request", (canonical-request request (get authorization :signed-headers)))
   (str/join "\n" [
     "AWS4-HMAC-SHA256"
     (format/unparse (format/formatters :basic-date-time-no-ms) request-time)

--- a/test/io/pithos/sig4_test.clj
+++ b/test/io/pithos/sig4_test.clj
@@ -1,8 +1,7 @@
 (ns io.pithos.sig4-test
   (:require [clojure.test   :refer :all]
             [clojure.string :refer [join]]
-            [io.pithos.sig4  :refer [canonical-request is-signed-by? parse-authorization request-time string-to-sign signature signing-key]])
-  (:import  [java.io StringReader]))
+            [io.pithos.sig4  :refer [canonical-request is-signed-by? parse-authorization request-time string-to-sign signature signing-key]]))
 
 (deftest sig4-canonical-request
   (testing "get-utf8"
@@ -10,12 +9,12 @@
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85"}
                                :request-method "GET"
-                               :uri "/ሴ"
-                               :params {}
-                               :body (StringReader. "")} ["x-amz-date", "host"])
+                               :orig-uri "/ሴ"
+                               :query-string ""
+                               :contents (.getBytes "")} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
-                        "/ሴ"
+                        "/%E1%88%B4"
                         ""
                         "host:example.amazonaws.com"
                         "x-amz-date:20150830T123600Z"
@@ -28,9 +27,9 @@
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
                                :request-method "GET"
-                               :uri "/"
-                               :params {}
-                               :body (StringReader. "")} ["x-amz-date", "host"])
+                               :orig-uri "/"
+                               :query-string ""
+                               :contents (.getBytes "")} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/"
@@ -46,9 +45,9 @@
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=a67d582fa61cc504c4bae71f336f98b97f1ea3c7a6bfe1b6e45aec72011b9aeb"}
                                :request-method "GET"
-                               :uri "/"
-                               :params {"Param1" "value1"}
-                               :body (StringReader. "")} ["x-amz-date", "host"])
+                               :orig-uri "/"
+                               :query-string "Param1=value1"
+                               :contents (.getBytes "")} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/"
@@ -64,9 +63,9 @@
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500"}
                                :request-method "GET"
-                               :uri "/"
-                               :params {"Param2" "value2" "Param1" "value1"}
-                               :body (StringReader. "")} ["x-amz-date", "host"])
+                               :orig-uri "/"
+                               :query-string "Param2=value2&Param1=value1"
+                               :contents (.getBytes "")} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/"
@@ -82,9 +81,9 @@
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=9c3e54bfcdf0b19771a7f523ee5669cdf59bc7cc0884027167c21bb143a40197"}
                                :request-method "GET"
-                               :uri "/"
-                               :params {"-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" "-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"}
-                               :body (StringReader. "")} ["x-amz-date", "host"])
+                               :orig-uri "/"
+                               :query-string "-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+                               :contents (.getBytes "")} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/"
@@ -100,13 +99,13 @@
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=2cdec8eed098649ff3a119c94853b13c643bcf08f8b0a1d91e12c9027818dd04"}
                                :request-method "GET"
-                               :uri "/"
-                               :params {"ሴ" "bar"}
-                               :body (StringReader. "")} ["x-amz-date", "host"])
+                               :orig-uri "/"
+                               :query-string "ሴ=bar"
+                               :contents (.getBytes "")} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/"
-                        "ሴ=bar"
+                        "%E1%88%B4=bar"
                         "host:example.amazonaws.com"
                         "x-amz-date:20150830T123600Z"
                         ""
@@ -118,9 +117,9 @@
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b"}
                                :request-method "POST"
-                               :uri "/"
-                               :params {}
-                               :body (StringReader. "")} ["x-amz-date", "host"])
+                               :orig-uri "/"
+                               :query-string ""
+                               :contents (.getBytes "")} ["x-amz-date", "host"])
 
             (join "\n" ["POST"
                         "/"
@@ -130,6 +129,44 @@
                         ""
                         "host;x-amz-date"
                         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"])))
+  )
+  (testing "regression-dash"
+    (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "host" "example.amazonaws.com"
+                                         "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=abab"}
+                               :request-method "POST"
+                               :orig-uri "/cd-1.iso"
+                               :query-string ""
+                               :contents (.getBytes "")} ["x-amz-date", "host"])
+
+            (join "\n" ["POST"
+                        "/cd-1.iso"
+                        ""
+                        "host:example.amazonaws.com"
+                        "x-amz-date:20150830T123600Z"
+                        ""
+                        "host;x-amz-date"
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"])))
+  )
+  (testing "regression-unsigned-payload"
+    (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "x-amz-content-sha256" "UNSIGNED-PAYLOAD"
+                                         "host" "example.amazonaws.com"
+                                         "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=abab"}
+                               :request-method "POST"
+                               :orig-uri "/"
+                               :query-string ""
+                               :contents (.getBytes "")} ["x-amz-content-sha256", "x-amz-date", "host"])
+
+            (join "\n" ["POST"
+                        "/"
+                        ""
+                        "host:example.amazonaws.com"
+                        "x-amz-content-sha256:UNSIGNED-PAYLOAD"
+                        "x-amz-date:20150830T123600Z"
+                        ""
+                        "host;x-amz-content-sha256;x-amz-date"
+                        "UNSIGNED-PAYLOAD"])))
   )
 )
 
@@ -145,9 +182,9 @@
                                            "host" "example.amazonaws.com"
                                            "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
                                  :request-method "GET"
-                                 :uri "/"
-                                 :params {}
-                                 :body (StringReader. "")})
+                                 :orig-uri "/"
+                                 :query-string ""
+                                 :contents (.getBytes "")})
 
             (join "\n" ["AWS4-HMAC-SHA256"
                         "20150830T123600Z"
@@ -168,9 +205,9 @@
                                       "host" "example.amazonaws.com"
                                       "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
                                  :request-method "GET"
-                                 :uri "/"
-                                 :params {}
-                                 :body (StringReader. "")})
+                                 :orig-uri "/"
+                                 :query-string ""
+                                 :contents (.getBytes "")})
 
             "5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"))
   )
@@ -185,9 +222,9 @@
                                       "host" "example.amazonaws.com"
                                       "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
                                  :request-method "GET"
-                                 :uri "/"
-                                 :params {}
-                                 :body (StringReader. "")}))
+                                 :orig-uri "/"
+                                 :query-string ""
+                                 :contents (.getBytes "")}))
   )
 
   (testing "real-captured-request-1"
@@ -199,8 +236,8 @@
                                       "content-length" "0"
                                       "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20170806/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=fdb4f1256d5c5a204d05d8126249a29d766b45d2c78c0908389714b87d949d20"}
                                  :request-method "GET"
-                                 :uri "/test/"
-                                 :params {"location" nil}
-                                 :body (StringReader. "")}))
+                                 :orig-uri "/test/"
+                                 :query-string "location="
+                                 :contents (.getBytes "")}))
   )
 )

--- a/test/io/pithos/sig4_test.clj
+++ b/test/io/pithos/sig4_test.clj
@@ -1,0 +1,206 @@
+(ns io.pithos.sig4-test
+  (:require [clojure.test   :refer :all]
+            [clojure.string :refer [join]]
+            [io.pithos.sig4  :refer [canonical-request is-signed-by? parse-authorization request-time string-to-sign signature signing-key]])
+  (:import  [java.io StringReader]))
+
+(deftest sig4-canonical-request
+  (testing "get-utf8"
+    (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "host" "example.amazonaws.com"
+                                         "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85"}
+                               :request-method "GET"
+                               :uri "/ሴ"
+                               :params {}
+                               :body (StringReader. "")} ["x-amz-date", "host"])
+
+            (join "\n" ["GET"
+                        "/ሴ"
+                        ""
+                        "host:example.amazonaws.com"
+                        "x-amz-date:20150830T123600Z"
+                        ""
+                        "host;x-amz-date"
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"])))
+  )
+  (testing "get-vanilla"
+    (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "host" "example.amazonaws.com"
+                                         "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
+                               :request-method "GET"
+                               :uri "/"
+                               :params {}
+                               :body (StringReader. "")} ["x-amz-date", "host"])
+
+            (join "\n" ["GET"
+                        "/"
+                        ""
+                        "host:example.amazonaws.com"
+                        "x-amz-date:20150830T123600Z"
+                        ""
+                        "host;x-amz-date"
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"])))
+  )
+  (testing "get-vanilla-empty-query-key"
+    (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "host" "example.amazonaws.com"
+                                         "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=a67d582fa61cc504c4bae71f336f98b97f1ea3c7a6bfe1b6e45aec72011b9aeb"}
+                               :request-method "GET"
+                               :uri "/"
+                               :params {"Param1" "value1"}
+                               :body (StringReader. "")} ["x-amz-date", "host"])
+
+            (join "\n" ["GET"
+                        "/"
+                        "Param1=value1"
+                        "host:example.amazonaws.com"
+                        "x-amz-date:20150830T123600Z"
+                        ""
+                        "host;x-amz-date"
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"])))
+  )
+  (testing "get-vanilla-query-order-key-case"
+    (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "host" "example.amazonaws.com"
+                                         "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500"}
+                               :request-method "GET"
+                               :uri "/"
+                               :params {"Param2" "value2" "Param1" "value1"}
+                               :body (StringReader. "")} ["x-amz-date", "host"])
+
+            (join "\n" ["GET"
+                        "/"
+                        "Param1=value1&Param2=value2"
+                        "host:example.amazonaws.com"
+                        "x-amz-date:20150830T123600Z"
+                        ""
+                        "host;x-amz-date"
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"])))
+  )
+  (testing "get-vanilla-query-unreserved"
+    (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "host" "example.amazonaws.com"
+                                         "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=9c3e54bfcdf0b19771a7f523ee5669cdf59bc7cc0884027167c21bb143a40197"}
+                               :request-method "GET"
+                               :uri "/"
+                               :params {"-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" "-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"}
+                               :body (StringReader. "")} ["x-amz-date", "host"])
+
+            (join "\n" ["GET"
+                        "/"
+                        "-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+                        "host:example.amazonaws.com"
+                        "x-amz-date:20150830T123600Z"
+                        ""
+                        "host;x-amz-date"
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"])))
+  )
+  (testing "get-vanilla-utf8-query"
+    (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "host" "example.amazonaws.com"
+                                         "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=2cdec8eed098649ff3a119c94853b13c643bcf08f8b0a1d91e12c9027818dd04"}
+                               :request-method "GET"
+                               :uri "/"
+                               :params {"ሴ" "bar"}
+                               :body (StringReader. "")} ["x-amz-date", "host"])
+
+            (join "\n" ["GET"
+                        "/"
+                        "ሴ=bar"
+                        "host:example.amazonaws.com"
+                        "x-amz-date:20150830T123600Z"
+                        ""
+                        "host;x-amz-date"
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"])))
+  )
+  (testing "post-vanilla"
+    (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "host" "example.amazonaws.com"
+                                         "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b"}
+                               :request-method "POST"
+                               :uri "/"
+                               :params {}
+                               :body (StringReader. "")} ["x-amz-date", "host"])
+
+            (join "\n" ["POST"
+                        "/"
+                        ""
+                        "host:example.amazonaws.com"
+                        "x-amz-date:20150830T123600Z"
+                        ""
+                        "host;x-amz-date"
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"])))
+  )
+)
+
+(defn test-string-to-sign [request]
+  (let [
+    request-time (request-time request)
+    authorization (parse-authorization request)]
+    (string-to-sign request request-time authorization)))
+
+(deftest sig4-string-to-sign
+  (testing "get-vanilla"
+    (is (= (test-string-to-sign {:headers {"x-amz-date" "20150830T123600Z"
+                                           "host" "example.amazonaws.com"
+                                           "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
+                                 :request-method "GET"
+                                 :uri "/"
+                                 :params {}
+                                 :body (StringReader. "")})
+
+            (join "\n" ["AWS4-HMAC-SHA256"
+                        "20150830T123600Z"
+                        "20150830/us-east-1/service/aws4_request"
+                        "bb579772317eb040ac9ed261061d46c1f17a8133879d6129b6e1c25292927e63"])))
+  )
+)
+
+(defn test-signature [request]
+  (let [
+    request-time (request-time request)
+    authorization (parse-authorization request)]
+    (signature (signing-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY" request-time authorization) (string-to-sign request request-time authorization))))
+
+(deftest sig4-signature
+  (testing "get-vanilla"
+    (is (= (test-signature {:headers {"x-amz-date" "20150830T123600Z"
+                                      "host" "example.amazonaws.com"
+                                      "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
+                                 :request-method "GET"
+                                 :uri "/"
+                                 :params {}
+                                 :body (StringReader. "")})
+
+            "5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"))
+  )
+)
+
+(defn test-is-signed-by [request]
+  (is-signed-by? request (parse-authorization request) "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"))
+
+(deftest sig4-is-signed-by
+  (testing "get-vanilla"
+    (is (test-is-signed-by {:headers {"x-amz-date" "20150830T123600Z"
+                                      "host" "example.amazonaws.com"
+                                      "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
+                                 :request-method "GET"
+                                 :uri "/"
+                                 :params {}
+                                 :body (StringReader. "")}))
+  )
+
+  (testing "real-captured-request-1"
+    ;; This was captured when running 's3cmd mb s3://test' (so the signature was generated by s3cmd/boto)
+    (is (test-is-signed-by {:headers {"x-amz-date" "20170806T173430Z"
+                                      "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                                      "host" "s3.example.com"
+                                      "accept-encoding" "identity"
+                                      "content-length" "0"
+                                      "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20170806/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=fdb4f1256d5c5a204d05d8126249a29d766b45d2c78c0908389714b87d949d20"}
+                                 :request-method "GET"
+                                 :uri "/test/"
+                                 :params {"location" nil}
+                                 :body (StringReader. "")}))
+  )
+)

--- a/test/io/pithos/sig4_test.clj
+++ b/test/io/pithos/sig4_test.clj
@@ -1,17 +1,18 @@
 (ns io.pithos.sig4-test
   (:require [clojure.test   :refer :all]
             [clojure.string :refer [join]]
-            [io.pithos.sig4  :refer [canonical-request is-signed-by? parse-authorization request-time string-to-sign signature signing-key]]))
+            [io.pithos.sig4  :refer [canonical-request is-signed-by? parse-authorization request-time string-to-sign signature signing-key sha256-input-stream]])
+  (:import  [java.io ByteArrayInputStream]))
 
 (deftest sig4-canonical-request
   (testing "get-utf8"
     (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85"}
                                :request-method "GET"
                                :orig-uri "/ሴ"
-                               :query-string ""
-                               :contents (.getBytes "")} ["x-amz-date", "host"])
+                               :query-string ""} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/%E1%88%B4"
@@ -24,12 +25,12 @@
   )
   (testing "get-vanilla"
     (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
                                :request-method "GET"
                                :orig-uri "/"
-                               :query-string ""
-                               :contents (.getBytes "")} ["x-amz-date", "host"])
+                               :query-string ""} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/"
@@ -42,12 +43,12 @@
   )
   (testing "get-vanilla-empty-query-key"
     (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=a67d582fa61cc504c4bae71f336f98b97f1ea3c7a6bfe1b6e45aec72011b9aeb"}
                                :request-method "GET"
                                :orig-uri "/"
-                               :query-string "Param1=value1"
-                               :contents (.getBytes "")} ["x-amz-date", "host"])
+                               :query-string "Param1=value1"} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/"
@@ -60,12 +61,12 @@
   )
   (testing "get-vanilla-query-order-key-case"
     (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500"}
                                :request-method "GET"
                                :orig-uri "/"
-                               :query-string "Param2=value2&Param1=value1"
-                               :contents (.getBytes "")} ["x-amz-date", "host"])
+                               :query-string "Param2=value2&Param1=value1"} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/"
@@ -78,12 +79,12 @@
   )
   (testing "get-vanilla-query-unreserved"
     (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=9c3e54bfcdf0b19771a7f523ee5669cdf59bc7cc0884027167c21bb143a40197"}
                                :request-method "GET"
                                :orig-uri "/"
-                               :query-string "-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-                               :contents (.getBytes "")} ["x-amz-date", "host"])
+                               :query-string "-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/"
@@ -96,12 +97,12 @@
   )
   (testing "get-vanilla-utf8-query"
     (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=2cdec8eed098649ff3a119c94853b13c643bcf08f8b0a1d91e12c9027818dd04"}
                                :request-method "GET"
                                :orig-uri "/"
-                               :query-string "ሴ=bar"
-                               :contents (.getBytes "")} ["x-amz-date", "host"])
+                               :query-string "ሴ=bar"} ["x-amz-date", "host"])
 
             (join "\n" ["GET"
                         "/"
@@ -114,12 +115,12 @@
   )
   (testing "post-vanilla"
     (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b"}
                                :request-method "POST"
                                :orig-uri "/"
-                               :query-string ""
-                               :contents (.getBytes "")} ["x-amz-date", "host"])
+                               :query-string ""} ["x-amz-date", "host"])
 
             (join "\n" ["POST"
                         "/"
@@ -132,12 +133,12 @@
   )
   (testing "regression-dash"
     (is (= (canonical-request {:headers {"x-amz-date" "20150830T123600Z"
+                                         "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                          "host" "example.amazonaws.com"
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=abab"}
                                :request-method "POST"
                                :orig-uri "/cd-1.iso"
-                               :query-string ""
-                               :contents (.getBytes "")} ["x-amz-date", "host"])
+                               :query-string ""} ["x-amz-date", "host"])
 
             (join "\n" ["POST"
                         "/cd-1.iso"
@@ -155,8 +156,7 @@
                                          "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=abab"}
                                :request-method "POST"
                                :orig-uri "/"
-                               :query-string ""
-                               :contents (.getBytes "")} ["x-amz-content-sha256", "x-amz-date", "host"])
+                               :query-string ""} ["x-amz-content-sha256", "x-amz-date", "host"])
 
             (join "\n" ["POST"
                         "/"
@@ -179,12 +179,12 @@
 (deftest sig4-string-to-sign
   (testing "get-vanilla"
     (is (= (test-string-to-sign {:headers {"x-amz-date" "20150830T123600Z"
+                                           "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                            "host" "example.amazonaws.com"
                                            "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
                                  :request-method "GET"
                                  :orig-uri "/"
-                                 :query-string ""
-                                 :contents (.getBytes "")})
+                                 :query-string ""})
 
             (join "\n" ["AWS4-HMAC-SHA256"
                         "20150830T123600Z"
@@ -202,12 +202,12 @@
 (deftest sig4-signature
   (testing "get-vanilla"
     (is (= (test-signature {:headers {"x-amz-date" "20150830T123600Z"
+                                      "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                       "host" "example.amazonaws.com"
                                       "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
                                  :request-method "GET"
                                  :orig-uri "/"
-                                 :query-string ""
-                                 :contents (.getBytes "")})
+                                 :query-string ""})
 
             "5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"))
   )
@@ -219,12 +219,12 @@
 (deftest sig4-is-signed-by
   (testing "get-vanilla"
     (is (test-is-signed-by {:headers {"x-amz-date" "20150830T123600Z"
+                                      "x-amz-content-sha256" "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                       "host" "example.amazonaws.com"
                                       "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"}
                                  :request-method "GET"
                                  :orig-uri "/"
-                                 :query-string ""
-                                 :contents (.getBytes "")}))
+                                 :query-string ""}))
   )
 
   (testing "real-captured-request-1"
@@ -237,7 +237,34 @@
                                       "authorization" "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20170806/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=fdb4f1256d5c5a204d05d8126249a29d766b45d2c78c0908389714b87d949d20"}
                                  :request-method "GET"
                                  :orig-uri "/test/"
-                                 :query-string "location="
-                                 :contents (.getBytes "")}))
+                                 :query-string "location="}))
+  )
+)
+
+(deftest body-validating-input-stream
+  (testing "signature-failure-no-body"
+    (print "signature-failure-no-body ")
+    (let [stream (sha256-input-stream (ByteArrayInputStream. (.getBytes "")) "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03") ba (byte-array 1024)]
+      (.read stream ba)
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"body signature is incorrect"
+                            (.close stream))))
+  )
+
+  (testing "empty-body"
+    (print "empty-body ")
+    (let [stream (sha256-input-stream (ByteArrayInputStream. (.getBytes "")) "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855") ba (byte-array 1024)]
+       (is (.read stream ba) -1)
+       (.close stream)
+    )
+  )
+
+  (testing "hello"
+    (print "hello ")
+    (let [stream (sha256-input-stream (ByteArrayInputStream. (.getBytes "hello")) "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824") ba (byte-array 1024)]
+       (is (.read stream ba) 5)
+       (.close stream)
+       ;; (is (= (take 5 (seq ba)) (seq (.getBytes "hello"))))
+    )
   )
 )


### PR DESCRIPTION
As of e75d433 I am able to create buckets, list bucket contents, upload and then download files using s3cmd. I've done multipart uploads of > 20 parts happily with it. I have also had it working with other internal s3 stuff, including ranged requests.

This is still very WIP - and only targets a subset of the sig4 signing styles (e.g. no chunked uploads).

It's definitely not ready to merge, but i have no prior experience with clojure and I don't know quite how bad this is 😱, so early feedback would be good.

There are also some questions for the maintainers.

 * `:uri` is replaced. Bucket path rewriting happens before the authorization code runs. This was invalidating the signatures. So i create an `:orig-uri` before this happens. Is there a better way?

* You can only read `:body` once. For testing I have just read `:body` as bytes into `:contents` and then attached a stream to `:body` that wraps `:contents`. This doesn't seem ideal. I can probably use `x-amz-content-sha256` to avoid shaing the body myself - it looks like its required for sig4 - but I haven't gone down that route yet. In that case I'd wrap `:body` in something that would error later on if it was closed and the final sha didn't match the header. I don't know if that is achievable in pithos, though. (E.g. might it just be too late...). Again, can you suggest a better way?