### PR TITLE
Prevent eaio uuid from being fetched over HTTP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: clojure
-lein: lein2
+lein: lein
 jdk:
   - oraclejdk8
 branches:

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,9 @@
                  [ring/ring-core                "1.3.2"
                   :exclusions [org.clojure/tools.reader]]
                  [ring/ring-codec               "1.0.0"]
-                 [cc.qbits/alia-all             "3.3.0"]
+                 [com.eaio.uuid/uuid            "3.2"]
+                 [cc.qbits/alia-all             "3.3.0"
+                  :exclusions [com.eaio.uuid/uuid]]
                  [cc.qbits/hayt                 "3.0.1"]
                  [cc.qbits/jet                  "0.7.9"
                   :exclusions [org.clojure/tools.reader]]


### PR DESCRIPTION
The original com.eaio.uuid package maintainer seems to not have pushed
version 3.3 of uuid to a reliable public repository. This fixes the
problem by forcing the use of 3.2 instead.

Tests pass and it doesn't seem like 3.2 regresses anything.

This fixes #165 

I also took the opportunity to fix the travis file (they switched from lein1 to lein2 as default).