### PR TITLE
Use "lein" instead of "lein2"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: clojure
-lein: lein2
+lein: lein
 jdk:
   - oraclejdk8
 branches:


### PR DESCRIPTION
Travis seems to have switched the default around, and instead of
defaulting to lein 1.x "lein" now points to "lein 2.x".

Legacy users now have to use "lein1" instead.